### PR TITLE
feat: scaffold flashcard CRUD & UI pages (draft)

### DIFF
--- a/prisma/migrations/20250527140546_add_flashcard_sets/migration.sql
+++ b/prisma/migrations/20250527140546_add_flashcard_sets/migration.sql
@@ -1,0 +1,39 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `userId` on the `Flashcard` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[question,setId]` on the table `Flashcard` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `setId` to the `Flashcard` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updatedAt` to the `Flashcard` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Flashcard" DROP CONSTRAINT "Flashcard_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "Flashcard" DROP COLUMN "userId",
+ADD COLUMN     "setId" TEXT NOT NULL,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;
+
+-- CreateTable
+CREATE TABLE "FlashcardSet" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FlashcardSet_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FlashcardSet_name_userId_key" ON "FlashcardSet"("name", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Flashcard_question_setId_key" ON "Flashcard"("question", "setId");
+
+-- AddForeignKey
+ALTER TABLE "FlashcardSet" ADD CONSTRAINT "FlashcardSet_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Flashcard" ADD CONSTRAINT "Flashcard_setId_fkey" FOREIGN KEY ("setId") REFERENCES "FlashcardSet"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,17 +11,30 @@ datasource db {
 model User {
   id        String   @id @default(cuid())
   clerkId   String   @unique
+  sets      FlashcardSet[]
   createdAt DateTime @default(now())
-  flashcards Flashcard[]
+}
+
+model FlashcardSet {
+  id         String   @id @default(cuid())
+  name       String
+  cards      Flashcard[]
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId     String
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  @@unique([name, userId])
 }
 
 model Flashcard {
   id         String   @id @default(cuid())
   question   String
   answer     String
+  set        FlashcardSet @relation(fields: [setId], references: [id], onDelete: Cascade)
+  setId      String
   createdAt  DateTime @default(now())
-  user       User     @relation(fields: [userId], references: [id])
-  userId     String
+  updatedAt  DateTime @updatedAt
 
-  @@unique([question, answer, userId])
+  @@unique([question, setId])
 }

--- a/src/app/api/flashcards/save/route.ts
+++ b/src/app/api/flashcards/save/route.ts
@@ -17,8 +17,7 @@ export async function POST(req: NextRequest) {
   const { cards } = await req.json();
   const result = await prisma.flashcard.createMany({
     data: cards.map((card: { question: string; answer: string }) => ({
-      question: card.question,
-      answer: card.answer,
+      ...card,
       userId: dbUser.id,
     })),
     skipDuplicates: true,

--- a/src/app/api/sets/[setId]/cards/route.ts
+++ b/src/app/api/sets/[setId]/cards/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ setId: string }> }
+) {
+  const { setId } = await params;
+
+  const { userId } = getAuth(req);
+  if (!userId)
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+
+  const { cards } = await req.json();
+  if (!Array.isArray(cards || cards.length === 0))
+    return NextResponse.json({ error: "Invalid cards data" }, { status: 400 });
+
+  try {
+    const result = await prisma.flashcard.createMany({
+      data: cards.map((card: { question: string; answer: string }) => ({
+        ...card,
+        setId,
+      })),
+      skipDuplicates: true,
+    });
+    return NextResponse.json({ inserted: result.count });
+  } catch (err) {
+    console.error("Error creating cards:", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Unknown error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/sets/[setId]/route.ts
+++ b/src/app/api/sets/[setId]/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ setId: string }> }
+) {
+  const { setId } = await params;
+
+  const { userId: clerkId } = getAuth(req);
+  if (!clerkId)
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  const user = await prisma.user.findUnique({ where: { clerkId } });
+  if (!user)
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+
+  const set = await prisma.flashcardSet.findFirst({
+    where: { id: setId, userId: user.id },
+    include: { cards: true },
+  });
+  if (!set)
+    return NextResponse.json({ error: "Set not found" }, { status: 404 });
+  return NextResponse.json(set);
+}

--- a/src/app/api/sets/route.ts
+++ b/src/app/api/sets/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(req: NextRequest) {
+  const { userId: clerkId } = getAuth(req);
+  if (!clerkId)
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  const user = await prisma.user.findUnique({ where: { clerkId } });
+  if (!user)
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+
+  const sets = await prisma.flashcardSet.findMany({
+    where: { userId: user.id },
+    include: { _count: { select: { cards: true } } },
+    orderBy: { createdAt: "desc" },
+  });
+  return NextResponse.json(sets);
+}
+
+export async function POST(req: NextRequest) {
+  const { userId: clerkId } = getAuth(req);
+  if (!clerkId)
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+
+  const { name, cards } = await req.json();
+  if (typeof name !== "string" || !name.trim())
+    return NextResponse.json({ error: "Invalid set name" }, { status: 400 });
+
+  try {
+    const newSet = await prisma.flashcardSet.create({
+      data: {
+        name: name.trim(),
+        user: { connectOrCreate: { where: { clerkId }, create: { clerkId } } },
+        cards: {
+          create: Array.isArray(cards)
+            ? cards.map((c: { question: string; answer: string }) => ({ ...c }))
+            : [],
+        },
+      },
+      include: { cards: true },
+    });
+    return NextResponse.json(newSet, { status: 201 });
+  } catch (err) {
+    console.error("Error creating set:", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Unknown error" },
+      { status: 400 }
+    );
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { SignedIn, SignedOut, useAuth } from "@clerk/nextjs";
+import { NewSetForm } from "@/components/NewSetForm";
+import { Button } from "@/components/ui/button";
+
+interface SetItem {
+  id: string;
+  name: string;
+  _count: { cards: number };
+}
+
+export default function Dashboard() {
+  const { isSignedIn } = useAuth();
+  const [sets, setSets] = useState<SetItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isSignedIn) return;
+
+    setLoading(true);
+
+    fetch("/api/sets")
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to fetch sets");
+        return res.json();
+      })
+      .then(setSets)
+      .catch((err) => {
+        console.error(err);
+        setError(err instanceof Error ? err.message : "Unknown error");
+      })
+      .finally(() => setLoading(false));
+  }, [isSignedIn]);
+
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold mb-6">Your Flashcard Sets</h1>
+
+      <SignedOut>
+        <p>Please sign in to view or create sets.</p>
+      </SignedOut>
+
+      <SignedIn>
+        <div className="mb-8">
+          <NewSetForm onCreate={(id) => router.push(`/sets/${id}`)} />
+        </div>
+        {loading ? (
+          <p>Loading your sets...</p>
+        ) : error ? (
+          <p className="text-red-600 mb-4">Error: {error}</p>
+        ) : sets.length === 0 ? (
+          <p>No flashcard sets found. Create a new set to get started!</p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {sets.map((set) => (
+              <div
+                key={set.id}
+                className="p-4 border rounded-xl hover:shadow transition"
+              >
+                <h2 className="text-lg font-semibold">{set.name}</h2>
+                <p className="text-sm text-gray-600">
+                  {set._count.cards} card{set._count.cards === 1 ? "" : "s"}
+                </p>
+                <Link href={`/sets/${set.id}`}>
+                  <Button className="mt-4">View &amp; Edit</Button>
+                </Link>
+              </div>
+            ))}
+          </div>
+        )}
+      </SignedIn>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,143 +1,52 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { ClientUploadedFileData } from "uploadthing/types";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { NewSetForm } from "@/components/NewSetForm";
+import { UploadZone } from "@/components/UploadZone";
+import { generateFromUrls } from "@/lib/flashcardApi";
 import { Flashcard } from "@/lib/flashcards";
-import { UploadDropzone, useUploadThing } from "@/lib/uploadthing";
 
 export default function Home() {
+  const [stage, setStage] = useState<"upload" | "preview">("upload");
   const [cards, setCards] = useState<Flashcard[]>([]);
-  const [savedCount, setSavedCount] = useState<number | null>(null);
-  const [hasSaved, setHasSaved] = useState(true);
 
-  const { startUpload } = useUploadThing("pdfAndTxt");
+  const router = useRouter();
 
-  useEffect(() => {
-    (async () => {
-      try {
-        const res = await fetch("/api/flashcards");
-        if (res.ok) {
-          const { cards: saved } = await res.json();
-          setCards(saved);
-        } else {
-          console.error("Failed to load cards:", res.status, res.statusText);
-        }
-      } catch (err) {
-        console.error("Error fetching cards:", err);
-      }
-    })();
-  }, []);
+  async function onUploadComplete(files: { ufsUrl: string }[]) {
+    const urls = files.map((f) => f.ufsUrl);
+    const generated = await generateFromUrls(urls);
+    if (generated.length === 0)
+      return alert("No flashcards generated. Please try again.");
+    setCards(generated);
+    setStage("preview");
+  }
 
-  const handleUploadComplete = async (
-    files: ClientUploadedFileData<null>[]
-  ) => {
-    if (files.length === 0) return;
-
-    try {
-      const url = files[0].ufsUrl;
-      const extRes = await fetch("/api/flashcards/extract-text", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ url }),
-      });
-      if (!extRes.ok) throw new Error(await extRes.text());
-      const { text } = await extRes.json();
-
-      const genRes = await fetch("/api/flashcards/generate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text: text }),
-      });
-      if (!genRes.ok) throw new Error(await genRes.text());
-      const { cards: newCards } = await genRes.json();
-      if (newCards.length === 0) {
-        alert("No flashcards generated from the uploaded file.");
-        return;
-      }
-
-      setCards((prev) => [...newCards, ...prev]);
-      setSavedCount(null);
-      setHasSaved(false);
-    } catch (err) {
-      console.error("Error processing upload:", err);
-      alert(
-        `Failed to process upload: ${
-          err instanceof Error ? err.message : "Unknown error"
-        }`
-      );
+  function renderStage() {
+    switch (stage) {
+      case "upload":
+        return <UploadZone onClientUploadComplete={onUploadComplete} />;
+      case "preview":
+        return (
+          <>
+            <ul className="space-y-4 max-h-64 overflow-auto">
+              {cards.map((c, i) => (
+                <li key={i} className="border p-3 rounded">
+                  <p className="font-semibold">{c.question}</p>
+                  <p>{c.answer}</p>
+                </li>
+              ))}
+            </ul>
+            <NewSetForm
+              cards={cards}
+              onCreate={(id) => router.push(`/sets/${id}`)}
+            />
+          </>
+        );
     }
-  };
-
-  const saveCards = async () => {
-    if (cards.length === 0) return;
-
-    try {
-      const res = await fetch("/api/flashcards/save", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ cards }),
-      });
-      const payload = await res.json();
-      if (!res.ok) throw new Error(payload.error ?? "Unknown error");
-
-      setSavedCount(payload.savedCount);
-      setHasSaved(true);
-    } catch (err) {
-      console.error("Error saving cards:", err);
-      alert(
-        `Failed to save cards: ${
-          err instanceof Error ? err.message : "Unknown error"
-        }`
-      );
-    }
-  };
+  }
 
   return (
-    <main className="p-8 space-y-6">
-      <h1 className="text-2xl font-bold">Your Dashboard</h1>
-
-      <>
-        <UploadDropzone
-          endpoint="pdfAndTxt"
-          onClientUploadComplete={handleUploadComplete}
-          onUploadError={(err) => alert(err.message)}
-        />
-        <input
-          type="file"
-          multiple
-          onChange={async (e) => {
-            const files = Array.from(e.target.files ?? []);
-            await startUpload(files);
-          }}
-        />
-      </>
-
-      {cards.length === 0 ? (
-        <p>No flashcards yet: Upload a file to get started!</p>
-      ) : (
-        <>
-          <ul className="grid gap-4">
-            {cards.map((card, i) => (
-              <li key={i} className="p-4 border rounded-lg">
-                <p className="font-semibold">{card.question}</p>
-                <p>{card.answer}</p>
-              </li>
-            ))}
-          </ul>
-
-          <button
-            className="px-4 py-2 bg-blue-600 text-white rounded"
-            onClick={saveCards}
-            disabled={hasSaved}
-          >
-            {hasSaved ? "Saved" : "Save to My Deck"}
-          </button>
-
-          {savedCount !== null && (
-            <p>{savedCount} cards saved to your account!</p>
-          )}
-        </>
-      )}
-    </main>
+    <main className="p-8 mx-auto max-w-xl space-y-6">{renderStage()}</main>
   );
 }

--- a/src/app/sets/[setId]/page.tsx
+++ b/src/app/sets/[setId]/page.tsx
@@ -39,7 +39,10 @@ export default function SetEditor() {
       return;
     }
     await appendCardsToSet(setId, newCards);
-    setCards((prev) => [...newCards, ...prev]);
+
+    const res = await fetch(`/api/sets/${setId}`);
+    if (!res.ok) throw new Error("Failed to refresh set");
+    setCards(await res.json().then((data) => data.cards));
   }
 
   return (

--- a/src/app/sets/[setId]/page.tsx
+++ b/src/app/sets/[setId]/page.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { UploadZone } from "@/components/UploadZone";
+import { appendCardsToSet, generateFromUrls } from "@/lib/flashcardApi";
+import { Flashcard } from "@/lib/flashcards";
+
+export default function SetEditor() {
+  const { setId } = useParams() as { setId: string };
+  const [cards, setCards] = useState<Flashcard[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadSet() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/sets/${setId}`);
+        const payload = await res.json();
+        if (!res.ok) throw new Error(payload.error ?? "Failed to load set");
+        setCards(payload.cards);
+      } catch (err) {
+        console.error(err);
+        setError(err instanceof Error ? err.message : "Unknown error");
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadSet();
+  }, [setId]);
+
+  async function onUpload(files: { ufsUrl: string }[]) {
+    const urls = files.map((f) => f.ufsUrl);
+    const newCards = await generateFromUrls(urls);
+    if (newCards.length === 0) {
+      alert("No flashcards generated. Please try again with different files.");
+      return;
+    }
+    await appendCardsToSet(setId, newCards);
+    setCards((prev) => [...newCards, ...prev]);
+  }
+
+  return (
+    <main className="p-8 space-y-6">
+      {loading ? (
+        <p>Loading set...</p>
+      ) : error ? (
+        <p className="text-red-500">Error: {error}</p>
+      ) : (
+        <>
+          <UploadZone onClientUploadComplete={onUpload} />
+
+          <section>
+            <h2 className="text-xl font-semibold">Cards</h2>
+            <ul className="space-y-4">
+              {cards.map((c, i) => (
+                <li key={i} className="border p-3 rounded">
+                  <p className="font-semibold">{c.question}</p>
+                  <p>{c.answer}</p>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </>
+      )}
+    </main>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,21 +8,29 @@ import {
   UserButton,
 } from "@clerk/nextjs";
 import { Button } from "./ui/button";
+import Link from "next/link";
 
 export function Header() {
   return (
-    <header className="flex justify-end items-center p-4 gap-4 h-16">
-      <SignedOut>
-        <SignInButton mode="modal">
-          <Button>Sign In</Button>
-        </SignInButton>
-        <SignUpButton mode="modal">
-          <Button>Sign Up</Button>
-        </SignUpButton>
-      </SignedOut>
-      <SignedIn>
-        <UserButton />
-      </SignedIn>
+    <header className="flex justify-between items-center p-4 h-16">
+      <nav className="flex gap-4">
+        <Link href="/">Home</Link>
+        <Link href="/dashboard">Dashboard</Link>
+      </nav>
+
+      <div className="flex gap-4">
+        <SignedOut>
+          <SignInButton mode="modal">
+            <Button>Sign In</Button>
+          </SignInButton>
+          <SignUpButton mode="modal">
+            <Button>Sign Up</Button>
+          </SignUpButton>
+        </SignedOut>
+        <SignedIn>
+          <UserButton />
+        </SignedIn>
+      </div>
     </header>
   );
 }

--- a/src/components/NewSetForm.tsx
+++ b/src/components/NewSetForm.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { Button } from "./ui/button";
+import { Flashcard } from "@/lib/flashcards";
+import { createSetWithCards } from "@/lib/flashcardApi";
+
+interface Props {
+  cards?: Flashcard[];
+  onCreate: (setId: string) => void;
+}
+
+export function NewSetForm({ cards = [], onCreate }: Props) {
+  const [name, setName] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setCreating(true);
+
+    try {
+      const { setId } = await createSetWithCards(name, cards);
+      onCreate(setId);
+    } catch (err) {
+      console.error(err);
+      alert(
+        `Error creating set: ${
+          err instanceof Error ? err.message : "Unknown error"
+        }`
+      );
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex gap-2 mb-6">
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Enter new set name"
+        className="border rounded px-3 py-2 flex-grow"
+        disabled={creating}
+      />
+      <Button type="submit" disabled={creating || !name.trim()}>
+        {creating ? "Creating..." : "Save Set"}
+      </Button>
+    </form>
+  );
+}

--- a/src/components/UploadZone.tsx
+++ b/src/components/UploadZone.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { UploadDropzone } from "@/lib/uploadthing";
+import { ClientUploadedFileData } from "uploadthing/types";
+
+interface Props {
+  onClientUploadComplete: (files: ClientUploadedFileData<null>[]) => void;
+}
+
+export function UploadZone({ onClientUploadComplete }: Props) {
+  return (
+    <UploadDropzone
+      endpoint="pdfAndTxt"
+      onClientUploadComplete={onClientUploadComplete}
+      onUploadError={(err) => alert(err.message)}
+    />
+  );
+}

--- a/src/lib/flashcardApi.ts
+++ b/src/lib/flashcardApi.ts
@@ -1,0 +1,53 @@
+import { Flashcard } from "./flashcards";
+
+async function extractText(url: string): Promise<string> {
+  const res = await fetch("/api/flashcards/extract-text", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ url }),
+  });
+  if (!res.ok) throw new Error("Failed to extract text");
+  return (await res.json()).text;
+}
+
+async function generateCards(text: string): Promise<Flashcard[]> {
+  const res = await fetch("/api/flashcards/generate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  if (!res.ok) throw new Error("Failed to generate flashcards");
+  return (await res.json()).cards;
+}
+
+export async function generateFromUrls(urls: string[]): Promise<Flashcard[]> {
+  const texts = await Promise.all(urls.map(extractText));
+  const cards = await Promise.all(texts.map(generateCards));
+  return cards.flat();
+}
+
+export async function createSetWithCards(
+  name: string,
+  cards: Flashcard[]
+): Promise<{ setId: string }> {
+  const res = await fetch("/api/sets", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, cards }),
+  });
+  const payload = await res.json();
+  if (!res.ok) throw new Error(payload.error ?? "Failed to create set");
+  return { setId: payload.id };
+}
+
+export async function appendCardsToSet(
+  setId: string,
+  cards: Flashcard[]
+): Promise<void> {
+  const res = await fetch(`/api/sets/${setId}/cards`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ cards }),
+  });
+  if (!res.ok) throw new Error("Failed to append cards to set");
+}


### PR DESCRIPTION
This draft PR introduces the initial flashcard‐set infrastructure:

• Prisma models for FlashcardSet & Flashcard  
• App‐Router API routes under app/api/sets (GET/POST, GET by ID, POST cards)  
• Shared flashcardApi helpers: generateFromUrls, createSetWithCards, appendCardsToSet  
• Home page flow: UploadZone → preview → NewSetForm → redirect to editor  
• Dashboard page: list user’s sets, NewSetForm for empty‐set creation  
• SetEditor page: fetch & display cards, UploadZone to append  
• Deduplication fix to mirror skipDuplicates in UI  

Next steps (in follow‐up branch):  
– Inline editing of questions/answers in SetEditor  
– Manual “Add Card” form in SetEditor  
– PATCH endpoint for updating individual cards  
